### PR TITLE
Implement a rudimentary cache

### DIFF
--- a/url-cache-plugin/src/main/groovy/com/kageiit/urlCache/UrlCacheExtension.groovy
+++ b/url-cache-plugin/src/main/groovy/com/kageiit/urlCache/UrlCacheExtension.groovy
@@ -1,6 +1,7 @@
 package com.kageiit.urlCache
 
 import java.security.MessageDigest
+import java.util.concurrent.TimeUnit
 
 public final class UrlCacheExtension {
     private static final String FILE_NAME = "content"
@@ -8,10 +9,12 @@ public final class UrlCacheExtension {
 
     private final String cacheDir
     private final boolean isOffline
+    private final boolean forceRefresh
 
-    public UrlCacheExtension(String cacheDir, boolean isOffline) {
+    public UrlCacheExtension(String cacheDir, boolean isOffline, boolean forceRefresh) {
         this.cacheDir = cacheDir
         this.isOffline = isOffline
+        this.forceRefresh = forceRefresh
     }
 
     public final File get(String url) {
@@ -19,7 +22,17 @@ public final class UrlCacheExtension {
         contentDir.mkdirs()
 
         File content = new File(contentDir, FILE_NAME)
-        content.createNewFile()
+
+        boolean download
+        if (isOffline) {
+            download = false
+        } else {
+            download = forceRefresh || !content.exists() || (System.currentTimeMillis() - content.lastModified()) > TimeUnit.DAYS.toMillis(1)
+        }
+
+        if (!content.exists()) {
+            content.createNewFile()
+        }
 
         if (!isOffline) {
             try {

--- a/url-cache-plugin/src/main/groovy/com/kageiit/urlCache/UrlCachePlugin.groovy
+++ b/url-cache-plugin/src/main/groovy/com/kageiit/urlCache/UrlCachePlugin.groovy
@@ -14,6 +14,6 @@ class UrlCachePlugin implements Plugin<Project> {
         Gradle gradle = project.gradle
         project.extensions.add(URL_CACHE, new UrlCacheExtension(
                 "${gradle.gradleUserHomeDir}/caches/${URL_CACHE_DIRECTORY}",
-                gradle.startParameter.offline))
+                gradle.startParameter.offline, gradle.startParameter.refreshDependencies))
     }
 }

--- a/url-cache-plugin/src/test/groovy/com/kageiit/urlCache/UrlCachePluginTest.groovy
+++ b/url-cache-plugin/src/test/groovy/com/kageiit/urlCache/UrlCachePluginTest.groovy
@@ -8,7 +8,7 @@ class UrlCachePluginTest {
     public void urlCache_created() {
         File.createTempDir().with {
             deleteOnExit()
-            UrlCacheExtension urlCacheExtension = new UrlCacheExtension(absolutePath, true)
+            UrlCacheExtension urlCacheExtension = new UrlCacheExtension(absolutePath, true, false)
             File content = urlCacheExtension.get("test")
 
             assert content.name.equals("content")


### PR DESCRIPTION
I'd love to see this in the plugin. It's not necessary to download build scripts in each build as this slows down the process a lot. 